### PR TITLE
Allow the caller to specify the git repo to derive commit information from

### DIFF
--- a/post-packages-s3.sh
+++ b/post-packages-s3.sh
@@ -15,16 +15,24 @@ readonly SED="${SED:-/bin/sed}"
 readonly AWS_S3_SENSU_CI_BUILDS_BUCKET="sensu-ci-builds"
 
 if [[ -z "$1" ]]; then
-   echo "Usage: $0 [ deliverables directory ]" >&2
+   echo "Usage: $0 [ deliverables directory ] [ git repository ]" >&2
+   echo "[ git repository ] is optional; if empty, [ deliverables directory] " >&2
+   echo "will be used, but one must be a git repository (to obtain commit information)." >&2
    exit 1
 fi
 
 readonly deliverables_dir="$1"
 
-git_branch="$(cd $deliverables_dir && $GIT rev-parse --abbrev-ref HEAD)"
+if [[ -n "$2" ]]; then
+   readonly git_repo="$2"
+else
+   readonly git_repo="$deliverables_dir"
+fi
+
+git_branch="$(cd $git_repo && $GIT rev-parse --abbrev-ref HEAD)"
 git_branch_no_slashes="$(echo "$git_branch" | $SED -e 's:/:_:g')"
 
-build_date="$(cd $deliverables_dir && TZ='America/Los_Angeles' $GIT log -1 --format='%cd' --date=format:'%Y%m%d-%H%M' HEAD)"
+build_date="$(cd $git_repo && TZ='America/Los_Angeles' $GIT log -1 --format='%cd' --date=format:'%Y%m%d-%H%M' HEAD)"
 
 disable_execution_tracing
 export AWS_ACCESS_KEY_ID="$AWS_S3_SENSU_CI_BUILDS_ACCESS_KEY"


### PR DESCRIPTION
instead of just assuming the deliverables directory happens to be inside the git repo.

This provides us more flexibility when we're using objdirs, etc.

This changed because in `sensu-enterprise-go`, we're using objdirs and distdirs that are outside of the Git repo.