### PR TITLE
Add a script to automatically publish release artifacts to S3

### DIFF
--- a/publish-packages.sh
+++ b/publish-packages.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # $ publish-packages.sh sha branch semver
-# $ publish-packages.sh 39d2bf22c416f9a78f22c4817dc74ab62d7f4d63 release_5.11 5.11.1
-git_branch_no_slashes="$(echo "$2" | sed -e 's:/:_:g')"
-backend_postfix="$(aws s3 ls s3://sensu-ci-builds/$git_branch_no_slashes/ | grep $1 | awk '{print $2}')"
-aws s3 sync s3://sensu-ci-builds/$git_branch_no_slashes/${backend_postfix}deb s3://sensu.io/sensu-go/$3 --acl public-read
-aws s3 sync s3://sensu-ci-builds/$git_branch_no_slashes/${backend_postfix}msi s3://sensu.io/sensu-go/$3 --acl public-read
-aws s3 sync s3://sensu-ci-builds/$git_branch_no_slashes/${backend_postfix}rpm s3://sensu.io/sensu-go/$3 --acl public-read
-aws s3 cp s3://sensu-ci-builds/$git_branch_no_slashes/${backend_postfix}goreleaser s3://sensu.io/sensu-go/$3 --recursive --exclude "*" --include "*.txt" --include "*.tar.gz" --include "*.zip" --acl public-read
-aws s3 cp s3://sensu-ci-builds/$git_branch_no_slashes/${backend_postfix}log.txt s3://sensu.io/sensu-go/$3/log.txt
+# $ publish-packages.sh 39d2bf22c416f9a78f22c4817dc74ab62d7f4d63 release/5.11 5.11.1
+set -e
+git_branch_no_slashes="${2////_}"
+backend_postfix="$(aws s3 ls s3://sensu-ci-builds/"$git_branch_no_slashes"/ | grep "$1" | awk '{print $2}')"
+aws s3 sync s3://sensu-ci-builds/"$git_branch_no_slashes"/"$backend_postfix"deb s3://sensu.io/sensu-go/"$3" --acl public-read
+aws s3 sync s3://sensu-ci-builds/"$git_branch_no_slashes"/"$backend_postfix"msi s3://sensu.io/sensu-go/"$3" --acl public-read
+aws s3 sync s3://sensu-ci-builds/"$git_branch_no_slashes"/"$backend_postfix"rpm s3://sensu.io/sensu-go/"$3" --acl public-read
+aws s3 cp s3://sensu-ci-builds/"$git_branch_no_slashes"/"$backend_postfix"goreleaser s3://sensu.io/sensu-go/"$3" --recursive --exclude "*" --include "*.txt" --include "*.tar.gz" --include "*.zip" --acl public-read
+aws s3 cp s3://sensu-ci-builds/"$git_branch_no_slashes"/"$backend_postfix"log.txt s3://sensu.io/sensu-go/"$3"/log.txt


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

Closes https://github.com/sensu/sensu-enterprise-go/issues/272
Closes https://trello.com/c/nXUq3gHp/96-mob-publishing-aws-s3-release-artifacts

Step 56 on [5.next release checklist](https://docs.google.com/spreadsheets/d/1RFi6EF98drRnIi8Nd40doG4E0ochG8C8heO_dVtAWx8/edit#gid=0) has been updated with the new instructions

Usage (but don't test on `s3://sensu.io/sensu-go/`):
```
$ publish-packages.sh sha branch semver
$ publish-packages.sh 39d2bf22c416f9a78f22c4817dc74ab62d7f4d63 release_5.11 5.11.1
```