### PR TITLE
Update docker orb to 2.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@1.4.0
+  docker: circleci/docker@2.0.3
 
 workflows:
   docker:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The Ubuntu 16.04 executor in CircleCI (which is used by the current Docker orb that we use) is being removed on May 31, 2022. The executor has been updated to use Ubuntu 20.04 in newer versions of the Docker orb.

See the blog post for more information: https://circleci.com/blog/ubuntu-14-16-image-deprecation/?mkt_tok=NDg1LVpNSC02MjYAAAGD54jOMjueOPYV-PsfR0hoTxMpzm8Z_TV87vz8zHZxbk6GaHFYe3o6RkjYg3Fwv3QjOuhKIvLvb5DDTd64Bqt7yaUak5_UGjrzmGoXq4oi8Kjw

I will cherry pick this to the `main` branch once this has been merged.