### PR TITLE
use go 1.17.12 for RHEL builders

### DIFF
--- a/dockerfiles/rhel7-builder/Dockerfile
+++ b/dockerfiles/rhel7-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/go-toolset:1.16.12
+FROM registry.access.redhat.com/ubi7/go-toolset:1.17.12
 
 LABEL name="sensu/sensu-release" \
       maintainer="engineering@sensu.io"

--- a/dockerfiles/rhel8-builder/Dockerfile
+++ b/dockerfiles/rhel8-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12
 
 LABEL name="sensu/sensu-release" \
       maintainer="engineering@sensu.io"


### PR DESCRIPTION
Only the FIPS builds were mad at me for something I have been working on in enterprise. This seemed to fix the "missing go.sum entry" errors I was getting (for dependent packages.) I don't pretend to understand it

<img width="951" alt="image" src="https://user-images.githubusercontent.com/33990804/199854747-66747848-ebe8-4961-88a4-506315b03918.png">